### PR TITLE
Fix minor memory leak in command line parsing

### DIFF
--- a/dvtm.c
+++ b/dvtm.c
@@ -1801,6 +1801,7 @@ parse_args(int argc, char *argv[]) {
 				if (!(fifo = realpath(argv[arg], NULL)))
 					error("%s\n", strerror(errno));
 				setenv("DVTM_CMD_FIFO", fifo, 1);
+				free(fifo);
 				break;
 			}
 			default:


### PR DESCRIPTION
realpath(..., NULL) allocates buffer of size MAX_PATH bytes.
Then, setenv() copies the string it got (unlike putenv()).
So we should free this string, or else it is leaked.